### PR TITLE
Scroll to top when transit to other page

### DIFF
--- a/src/app/app-routing.module.ts
+++ b/src/app/app-routing.module.ts
@@ -19,7 +19,7 @@ const routes: Routes = [
 ];
 
 @NgModule({
-  imports: [RouterModule.forRoot(routes)],
+  imports: [RouterModule.forRoot(routes, { scrollPositionRestoration: "top" })],
   exports: [RouterModule]
 })
 export class AppRoutingModule { }


### PR DESCRIPTION
### 概要
ページ遷移時に、遷移元のスクロール量が保持されていたので、一番上にスクロールされるよう修正しました。

### 動作確認
#### 現状
![not_scroll_to_top](https://user-images.githubusercontent.com/28133383/92982723-82a32800-f4da-11ea-81b0-8fb555fa24f7.gif)

#### 本PR
![scroll_to_top](https://user-images.githubusercontent.com/28133383/92982731-8767dc00-f4da-11ea-910c-3f4edb5a4c37.gif)

